### PR TITLE
Add useMaster option to PushNotification 

### DIFF
--- a/session.go
+++ b/session.go
@@ -183,13 +183,8 @@ func (s *ParseSession) UploadInstallation(data Installation, result interface{})
 }
 
 // PushNotification sends push-notifiaction each device via parse
-func (s *ParseSession) PushNotification(body PushNotificationQuery) error {
-	return do(s.post("/push", false).Send(body), nil)
-}
-
-// MasterPushNotification sends push-notifiaction as master (master key) each device via parse
-func (s *ParseSession) MasterPushNotification(body PushNotificationQuery) error {
-	return do(s.post("/push", true).Send(body), nil)
+func (s *ParseSession) PushNotification(body PushNotificationQuery, useMaster bool) error {
+	return do(s.post("/push", useMaster).Send(body), nil)
 }
 
 // Execute a parse request

--- a/session.go
+++ b/session.go
@@ -183,8 +183,13 @@ func (s *ParseSession) UploadInstallation(data Installation, result interface{})
 }
 
 // PushNotification sends push-notifiaction each device via parse
-func (s *ParseSession) PushNotification(body PushNotificationQuery, useMaster bool) error {
-	return do(s.post("/push", useMaster).Send(body), nil)
+func (s *ParseSession) PushNotification(body PushNotificationQuery) error {
+	return do(s.post("/push", false).Send(body), nil)
+}
+
+// PushNotificationByMaster sends push-notifiaction as Master to each device via parse
+func (s *ParseSession) PushNotificationByMaster(body PushNotificationQuery) error {
+	return do(s.post("/push", true).Send(body), nil)
 }
 
 // Execute a parse request

--- a/session.go
+++ b/session.go
@@ -187,6 +187,11 @@ func (s *ParseSession) PushNotification(body PushNotificationQuery) error {
 	return do(s.post("/push", false).Send(body), nil)
 }
 
+// MasterPushNotification sends push-notifiaction as master (master key) each device via parse
+func (s *ParseSession) MasterPushNotification(body PushNotificationQuery) error {
+	return do(s.post("/push", true).Send(body), nil)
+}
+
 // Execute a parse request
 func do(req *gorequest.SuperAgent, data interface{}) error {
 

--- a/session_test.go
+++ b/session_test.go
@@ -262,11 +262,10 @@ func TestParseSession(t *testing.T) {
 						}
 						err := sessionInMaster.PushNotificationByMaster(body)
 
-						So(err, ShouldBeNil)
-
 						Convey("It returns no errors", func() {
 							So(err, ShouldBeNil)
 						})
+
 					})
 
 				})

--- a/session_test.go
+++ b/session_test.go
@@ -254,7 +254,7 @@ func TestParseSession(t *testing.T) {
 
 						body := PushNotificationQuery{
 							Where: map[string]interface{}{
-								"objectId": result.ObjectID,
+								"DeviceType": "android",
 							},
 							Data: map[string]string{
 								"alert": "master push",
@@ -337,7 +337,7 @@ func TestParseSession(t *testing.T) {
 
 		})
 
-		Convey("When sending push-notifiaction", func() {
+		Convey("When sending push-notification", func() {
 			user, err := session.Login("testuser", "testpass")
 			So(err, ShouldBeNil)
 

--- a/session_test.go
+++ b/session_test.go
@@ -249,6 +249,26 @@ func TestParseSession(t *testing.T) {
 							So(user2.SessionToken, ShouldNotBeEmpty)
 						})
 					})
+
+					Convey("When sending user push as master", func() {
+
+						body := PushNotificationQuery{
+							Where: map[string]interface{}{
+								"objectId": result.ObjectID,
+							},
+							Data: map[string]string{
+								"alert": "master push",
+							},
+						}
+						err := sessionInMaster.PushNotificationAsMaster(body)
+
+						So(err, ShouldBeNil)
+
+						Convey("It returns no errors", func() {
+							So(err, ShouldBeNil)
+						})
+					})
+
 				})
 
 				Convey("Parse class operation", func() {

--- a/session_test.go
+++ b/session_test.go
@@ -260,7 +260,7 @@ func TestParseSession(t *testing.T) {
 								"alert": "master push",
 							},
 						}
-						err := sessionInMaster.PushNotificationAsMaster(body)
+						err := sessionInMaster.PushNotificationByMaster(body)
 
 						So(err, ShouldBeNil)
 


### PR DESCRIPTION
We've recently moved to using our own Parse server and when attempting to send PushNotifications we had issues sending push's from this client b/c of the initRequest using REST vs Master Key. In order for us to be able to send these pushes we need to set useMaster flag to true. This PR adds an additional param to the PushNotification method to allow for this. Let me know your thoughts.