### PR TITLE
Added session token field to the response when updating user

### DIFF
--- a/model.go
+++ b/model.go
@@ -95,9 +95,10 @@ type (
 
 	// ObjectResponse data type
 	ObjectResponse struct {
-		ObjectID  string    `json:"objectId,omitempty"`
-		CreatedAt time.Time `json:"createdAt,omitempty"`
-		UpdatedAt time.Time `json:"updatedAt,omitempty"`
+		ObjectID     string    `json:"objectId,omitempty"`
+		SessionToken string    `json:"sessionToken,omitempty"`
+		CreatedAt    time.Time `json:"createdAt,omitempty"`
+		UpdatedAt    time.Time `json:"updatedAt,omitempty"`
 	}
 
 	// Error data type


### PR DESCRIPTION
When i update user's password, parse-server removes all the revocable session tokens
and generates a new revocable session token.

https://github.com/ParsePlatform/parse-server/blob/6979bb430b44bfe2d29a6b661be581fa8064bc9a/src/RestWrite.js#L353-L364

This library doesn't return new token, so i fixed it.
